### PR TITLE
Update typings for application: displayDialog

### DIFF
--- a/types/application.d.ts
+++ b/types/application.d.ts
@@ -43,7 +43,7 @@ interface Application {
         | Item; // …or an alias or file reference to a ‘.icns’ file
       givingUpAfter?: number; // number of seconds to wait before automatically dismissing the dialog
     }
-  ): { buttonReturned?: string };
+  ): DialogReply;
   /** Displays a dialog with choices. If the user chooses to cancel, `false` is
    * returned. Otherwise, a list of items selected is returned. */
   chooseFromList(
@@ -59,7 +59,14 @@ interface Application {
     }
   ): false | (number | string)[];
 }
+
 declare function Application(x: string | number): Application;
+
+interface DialogReply {
+  buttonReturned?: string; // name of button chosen (empty if ‘giving up after’ was supplied and dialog timed out)
+  textReturned?: string; //  text entered (present only if ‘default answer’ was supplied)
+  gaveUp: boolean; // Did the dialog time out? (present only if ‘giving up after’ was supplied)
+}
 
 interface Item {
   /** Get the class (string) of a selected item. */

--- a/types/application.d.ts
+++ b/types/application.d.ts
@@ -28,11 +28,20 @@ interface Application {
   displayDialog(
     message: string,
     args?: {
-      withTitle?: string;
-      defaultAnswer?: string;
-      buttons?: string[];
-      defaultButton?: number; // starts at index 1
-      withIcon?: number;
+      defaultAnswer?: string; // the default editable string
+      hiddenAnswer?: boolean; // Should editable text be displayed as bullets? (default is false)
+      buttons?: Arracy<string>; // a list of up to three button names
+      defaultButton?: string | number; // the name or number of the default button — NB: starts at index 1
+      cancelButton?: string | number; // the name or number of the cancel button
+      withTitle?: string; // the dialog window title
+      withIcon?:
+        | string // the resource name or ID of the icon to display…
+        | number
+        | "stop" // …or one of these system icons…
+        | "note"
+        | "caution"
+        | Item; // …or an alias or file reference to a ‘.icns’ file
+      givingUpAfter?: number; // number of seconds to wait before automatically dismissing the dialog
     }
   ): { buttonReturned?: string };
   /** Displays a dialog with choices. If the user chooses to cancel, `false` is

--- a/types/application.d.ts
+++ b/types/application.d.ts
@@ -30,7 +30,7 @@ interface Application {
     args?: {
       defaultAnswer?: string; // the default editable string
       hiddenAnswer?: boolean; // Should editable text be displayed as bullets? (default is false)
-      buttons?: Arracy<string>; // a list of up to three button names
+      buttons?: Array<string>; // a list of up to three button names
       defaultButton?: string | number; // the name or number of the default button — NB: starts at index 1
       cancelButton?: string | number; // the name or number of the cancel button
       withTitle?: string; // the dialog window title


### PR DESCRIPTION
Based on the current docs as of 11.5.2:

<img width="690" alt="Screen Shot 2021-08-21 at 18 04 29" src="https://user-images.githubusercontent.com/319655/130336140-5f1157dc-4c13-4d01-bb0b-1af0ac262c42.png">
